### PR TITLE
Updated the Bing API Endpoints

### DIFF
--- a/Kiosk/ServiceHelpers/BingSearchHelper.cs
+++ b/Kiosk/ServiceHelpers/BingSearchHelper.cs
@@ -45,9 +45,9 @@ namespace ServiceHelpers
 {
     public class BingSearchHelper
     {
-        private static string ImageSearchEndPoint = "https://bingapis.azure-api.net/api/v5/images/search";
-        private static string AutoSuggestionEndPoint = "https://bingapis.azure-api.net/api/v5/Suggestions";
-        private static string NewsSearchEndPoint = "https://bingapis.azure-api.net/api/v5/news/search";
+        private static string ImageSearchEndPoint = "https://api.cognitive.microsoft.com/bing/v5.0/images/search";
+        private static string AutoSuggestionEndPoint = "https://api.cognitive.microsoft.com/bing/v5.0/suggestions";
+        private static string NewsSearchEndPoint = "https://api.cognitive.microsoft.com/bing/v5.0/news/search";
 
         private static HttpClient autoSuggestionClient { get; set; }
         private static HttpClient searchClient { get; set; }


### PR DESCRIPTION
The Bing News Analytics demo was faling so I decided to hunt down the issue. Turns out that the Bing APIs have a new endpoint. I updated the endpoint and tested that demo along with the other demos to make sure nothing is broken. Let me know if you have any questions.

Orville
