### PR TITLE
added a setting to reduce age for unflattering light conditions

### DIFF
--- a/Kiosk/SettingsHelper.cs
+++ b/Kiosk/SettingsHelper.cs
@@ -195,6 +195,16 @@ namespace IntelligentKioskSample
                 }
             }
 
+            value = ApplicationData.Current.RoamingSettings.Values["PhotoAgeReductionPercentage"];
+            if (value != null)
+            {
+                uint size;
+                if (uint.TryParse(value.ToString(), out size))
+                {
+                    this.PhotoAgeReductionPercentage = size;
+                }
+            }
+
             value = ApplicationData.Current.RoamingSettings.Values["CustomVisionPredictionApiKey"];
             if (value != null)
             {
@@ -365,6 +375,19 @@ namespace IntelligentKioskSample
                 this.OnSettingChanged("MinDetectableFaceCoveragePercentage", value);
             }
         }
+
+        private uint photoAgeReductionPercentage = 0;
+        public uint PhotoAgeReductionPercentage
+        {
+            get { return this.photoAgeReductionPercentage; }
+            set
+            {
+                this.photoAgeReductionPercentage = value;
+                this.OnSettingChanged("PhotoAgeReductionPercentage", value);
+            }
+        }
+
+        
 
         private bool showDebugInfo = false;
         public bool ShowDebugInfo

--- a/Kiosk/Views/RealTimeDemo.xaml.cs
+++ b/Kiosk/Views/RealTimeDemo.xaml.cs
@@ -207,6 +207,12 @@ namespace IntelligentKioskSample.Views
             }
             else
             {
+                // offset ages
+                foreach ( Face f in e.DetectedFaces)
+                {
+                    f.FaceAttributes.Age = f.FaceAttributes.Age - (f.FaceAttributes.Age * SettingsHelper.Instance.PhotoAgeReductionPercentage / 100 );
+                }
+
                 this.lastDetectedFaceSample = e.DetectedFaces;
             }
         }

--- a/Kiosk/Views/SettingsPage.xaml
+++ b/Kiosk/Views/SettingsPage.xaml
@@ -53,6 +53,7 @@
                         <ComboBox Grid.Column="1" Margin="10,0,6,0" Header="Region" ItemsSource="{Binding AvailableApiRegions}" SelectedItem="{Binding FaceApiKeyRegion, Mode=TwoWay}"/>
                     </Grid>
 
+              
                     <Grid Margin="0,10,0,0">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition/>
@@ -86,7 +87,14 @@
                         <Slider x:Name="MinDetectableFaceSizeSlider" Minimum="0" Maximum="100" Value="{Binding MinDetectableFaceCoveragePercentage, Mode=TwoWay}" SmallChange="1" LargeChange="5" Header="Minimum detectable face size (as % of image height):" HorizontalAlignment="Left" Margin="0,0,0,0" StepFrequency="1"/>
                         <TextBlock Text="{Binding ElementName=MinDetectableFaceSizeSlider, Path=Value}" Style="{StaticResource TitleTextBlockStyle}" VerticalAlignment="Center" Margin="12,0,0,0"/>
                     </StackPanel>
-                 </StackPanel>
+                    
+                    <StackPanel Orientation="Horizontal">
+                        <Slider x:Name="PhotoAgeReductionPercent" Minimum="0" Maximum="20" Value="{Binding PhotoAgeReductionPercentage, Mode=TwoWay}" SmallChange="1" LargeChange="5" Header="% to reduce photo age (useful in unflattering light conditions):" HorizontalAlignment="Left" Margin="0,0,0,0" StepFrequency="1"/>
+                        <TextBlock Text="{Binding ElementName=PhotoAgeReductionPercentSlider, Path=Value}" Style="{StaticResource TitleTextBlockStyle}" VerticalAlignment="Center" Margin="12,0,0,0"/>
+                    </StackPanel>
+                    
+                    
+                </StackPanel>
 
                 <StackPanel Margin="0,25,0,0">
                     <TextBlock Text="Mall Kiosk" Style="{StaticResource SubheaderTextBlockStyle}"/>


### PR DESCRIPTION
I have added a setting to reduce the age values that come back as when the intelligent kiosk is running in certain light conditions it over estimates age and this can be a bit of a problem in the MTC with customers