### PR TITLE
Update to latest NuGet packages and fix compilation errors and warnings

### DIFF
--- a/Kiosk/CognitiveServiceApiKeyTester.cs
+++ b/Kiosk/CognitiveServiceApiKeyTester.cs
@@ -64,7 +64,7 @@ namespace IntelligentKioskSample
                     Endpoint = apiEndpoint
                 };
 
-                await client.SentimentAsync(
+                await client.SentimentAsync(multiLanguageBatchInput:
                         new MultiLanguageBatchInput(
                             new List<MultiLanguageInput>()
                             {

--- a/Kiosk/Controls/ImageWithFaceBorderUserControl.xaml.cs
+++ b/Kiosk/Controls/ImageWithFaceBorderUserControl.xaml.cs
@@ -468,11 +468,11 @@ namespace IntelligentKioskSample.Controls
                     {
                         foreach (var word in line.Words)
                         {
-                            int[] boundingBox = word?.BoundingBox?.ToArray() ?? new int[] { };
+                            double[] boundingBox = word?.BoundingBox?.ToArray() ?? new double[] { };
                             if (boundingBox.Length == 8)
                             {
-                                double minLeft = renderedImageXTransform * (new List<int>() { boundingBox[0], boundingBox[2], boundingBox[4], boundingBox[6] }).Min();
-                                double minTop = renderedImageYTransform * (new List<int>() { boundingBox[1], boundingBox[3], boundingBox[5], boundingBox[7] }).Min();
+                                double minLeft = renderedImageXTransform * (new List<double>() { boundingBox[0], boundingBox[2], boundingBox[4], boundingBox[6] }).Min();
+                                double minTop = renderedImageYTransform * (new List<double>() { boundingBox[1], boundingBox[3], boundingBox[5], boundingBox[7] }).Min();
                                 var points = new PointCollection()
                                 {
                                     new Windows.Foundation.Point(boundingBox[0] * renderedImageXTransform - minLeft, boundingBox[1] * renderedImageYTransform - minTop),

--- a/Kiosk/IntelligentKioskSample.csproj
+++ b/Kiosk/IntelligentKioskSample.csproj
@@ -528,7 +528,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision">
-      <Version>3.3.0</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.CustomVision.Prediction">
       <Version>0.12.0-preview</Version>
@@ -540,16 +540,16 @@
       <Version>2.2.0-preview</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.1.9</Version>
+      <Version>6.2.8</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Rest.ClientRuntime">
-      <Version>2.3.11</Version>
+      <Version>2.3.20</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.2</Version>
     </PackageReference>
     <PackageReference Include="WriteableBitmapEx">
-      <Version>1.5.0</Version>
+      <Version>1.6.2</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/Kiosk/KioskRuntimeComponent/KioskRuntimeComponent.csproj
+++ b/Kiosk/KioskRuntimeComponent/KioskRuntimeComponent.csproj
@@ -110,7 +110,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.1.0</Version>
+      <Version>6.2.8</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/Kiosk/ServiceHelpers/ServiceHelpers.csproj
+++ b/Kiosk/ServiceHelpers/ServiceHelpers.csproj
@@ -124,16 +124,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language.TextAnalytics">
-      <Version>2.8.0-preview</Version>
+      <Version>3.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision">
-      <Version>3.3.0</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.Face">
       <Version>2.2.0-preview</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.1.7</Version>
+      <Version>6.2.8</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup />

--- a/Kiosk/ServiceHelpers/TextAnalyticsHelper.cs
+++ b/Kiosk/ServiceHelpers/TextAnalyticsHelper.cs
@@ -113,7 +113,7 @@ namespace ServiceHelpers
                 inputList.Add(new MultiLanguageInput(language, i.ToString(), input[i]));
             }
 
-            SentimentBatchResult result = await client.SentimentAsync(new MultiLanguageBatchInput(inputList));
+            SentimentBatchResult result = await client.SentimentAsync(multiLanguageBatchInput: new MultiLanguageBatchInput(inputList));
             IEnumerable<double> scores = result.Documents.OrderBy(x => x.Id).Select(x => x.Score.GetValueOrDefault());
             return new SentimentResult { Scores = scores };
         }
@@ -136,7 +136,7 @@ namespace ServiceHelpers
                 inputList.Add(new MultiLanguageInput(language, i.ToString(), input[i]));
             }
 
-            KeyPhraseBatchResult result = await client.KeyPhrasesAsync(new MultiLanguageBatchInput(inputList));
+            KeyPhraseBatchResult result = await client.KeyPhrasesAsync(multiLanguageBatchInput: new MultiLanguageBatchInput(inputList));
             IEnumerable<IList<string>> keyPhrases = result.Documents.OrderBy(x => x.Id).Select(x => x.KeyPhrases);
             return new KeyPhrasesResult() { KeyPhrases = keyPhrases };
         }

--- a/Kiosk/Util.cs
+++ b/Kiosk/Util.cs
@@ -322,7 +322,7 @@ namespace IntelligentKioskSample
         private static async Task<Tuple<double, double>> ResizePhoto(Stream photo, int height, IRandomAccessStream resultStream)
         {
             WriteableBitmap wb = new WriteableBitmap(1, 1);
-            wb = await wb.FromStream(photo.AsRandomAccessStream());
+            wb = await BitmapFactory.FromStream(photo.AsRandomAccessStream());
 
             int originalWidth = wb.PixelWidth;
             int originalHeight = wb.PixelHeight;


### PR DESCRIPTION
I updated all the NuGet packages used by this sample to the latest (non-preview) versions and fixed the resulting compilation errors. 
I didn't update the Custom Vision packages as the newer versions use v3.0 of the API and these require a relatively major code change, as v3.0 requires Custom Vision models to be published first before being able to predict by them. This is subject to another PR.
