### PR TITLE
Fix result canvas ghosting issue

### DIFF
--- a/Kiosk/Views/InkRecognizerExplorer/InkMirror.xaml.cs
+++ b/Kiosk/Views/InkRecognizerExplorer/InkMirror.xaml.cs
@@ -176,7 +176,7 @@ namespace IntelligentKioskSample.Views.InkRecognizerExplorer
             }
             else if (activeTool is InkToolbarEraserButton)
             {
-                RedoButton_Click(null, null);
+                RedoButton_Click(sender, null);
             }
             else
             {
@@ -335,6 +335,7 @@ namespace IntelligentKioskSample.Views.InkRecognizerExplorer
                 //dipsPerMm = inkRecognizer.GetDipsPerMm(dpi);
 
                 dipsPerMm = inkRecognizer.GetDipsPerMm(96);
+                args.DrawingSession.Clear(Colors.White);
 
                 foreach (var recoUnit in inkResponse.RecognitionUnits)
                 {


### PR DESCRIPTION
This PR's goal is to fix the "ghosting" issue where rendered results on the result canvas appear to be sticky and not properly cleared. An example of this bug can be shown [here](https://streamable.com/6yds2).

Another bug is also fixed in this PR involving an unhandled exception being raised when the undo button is used after erasing a stroke.