### PR TITLE
Ink Recognizer - Set US Culture to get correct decimal separator

### DIFF
--- a/Kiosk/ServiceHelpers/InkRecognizer.cs
+++ b/Kiosk/ServiceHelpers/InkRecognizer.cs
@@ -103,7 +103,10 @@ namespace ServiceHelpers
 
             var payload = new JObject();
             var strokesArray = new JArray();
-
+            
+            //Set fixed CultureInfo for getting '.' as decimal seperator
+            CultureInfo ci = new CultureInfo("en-US");
+            
             foreach (InkStroke stroke in StrokeMap.Values)
             {
                 var jStroke = new JObject();
@@ -120,7 +123,9 @@ namespace ServiceHelpers
                         var transformedPoint = Vector2.Transform(new Vector2((float)pointsCollection[i].Position.X, (float)pointsCollection[i].Position.Y), transform);
                         double x = transformedPoint.X / dipsPerMm;
                         double y = transformedPoint.Y / dipsPerMm;
-                        points.Append($"{x},{y}");
+                        var x_str = x.ToString(ci);
+                        var y_str = y.ToString(ci);
+                        points.Append($"{x_str},{y_str}");
                         if (i != pointsCollection.Count - 1)
                         {
                             points.Append(",");


### PR DESCRIPTION
The Ink Recognizer is throwing errors when your local culture does not have the '.' point as a decimal seperator. Json polygon data looks like this then:
12,1234566,34,567890
Which is not valid for the API, it needs to be
12.1234566,34.567890

This can be fixed by setting a US culture.